### PR TITLE
Fix symmetry bug in deepEqualIdentStack

### DIFF
--- a/deepEqualIdentStack.js
+++ b/deepEqualIdentStack.js
@@ -18,6 +18,8 @@ function _stack(a, b) {
         // leave this to isEqual
       }
       break;
+    } else if (stackB[index] === b) {
+      return false;
     }
   }
   if (stackA[index] !== a) { // no match, found add to stack

--- a/runTestSuite.js
+++ b/runTestSuite.js
@@ -59,6 +59,7 @@ function runTestSuite(name, deepEqualIdent) {
       var bar = [a, b];
 
       expect(deepEqualIdent(foo, bar)).toBe(false);
+      expect(deepEqualIdent(bar, foo)).toBe(false);
     });
   });
 }


### PR DESCRIPTION
`_stack` already checked that distinct right objects map to distinct left objects, but must also check that distinct left objects map to distinct right objects.
